### PR TITLE
Fix Workday nav: Time link moved under Personal submenu

### DIFF
--- a/src/iptax/workday/driver.py
+++ b/src/iptax/workday/driver.py
@@ -49,6 +49,10 @@ class PlaywrightLocator:
         """Click the element."""
         await self._locator.click()
 
+    async def hover(self) -> None:
+        """Hover over the element."""
+        await self._locator.hover()
+
     async def fill(self, value: str) -> None:
         """Fill the element with text."""
         await self._locator.fill(value)

--- a/src/iptax/workday/protocols.py
+++ b/src/iptax/workday/protocols.py
@@ -36,6 +36,10 @@ class LocatorProtocol(Protocol):
         """Click the element."""
         ...
 
+    async def hover(self) -> None:
+        """Hover over the element."""
+        ...
+
     async def fill(self, value: str) -> None:
         """Fill the element with text (clears existing content)."""
         ...

--- a/src/iptax/workday/scraping.py
+++ b/src/iptax/workday/scraping.py
@@ -37,32 +37,26 @@ async def navigate_to_time_page(
     Uses the "Select Week" option to jump directly to the target date,
     which is much faster than navigating week by week.
 
+    The Workday home page now places "Time" under the "Personal" submenu,
+    which appears on hover. We hover over "Personal" then click "Time".
+
     Args:
         driver: Browser driver object
         target_date: The target date to navigate to
     """
-    logger.info("Looking for Time button...")
+    logger.info("Looking for Time link under Personal submenu...")
 
-    # Wait for the page to have the "Your Top Apps" section loaded
-    # Try to find the Time button with different strategies
-    time_button = driver.get_by_role("button", name="Time", exact=True)
+    # Hover over the "Personal" nav button to reveal submenu
+    personal_button = driver.get_by_role("button", name="Personal", exact=True)
+    await personal_button.wait_for(state="visible", timeout=ELEMENT_TIMEOUT)
+    await personal_button.hover()
+    logger.info("Hovered over Personal button, looking for Time link...")
 
-    # Wait for the Time button
-    try:
-        await time_button.wait_for(state="visible")
-    except Exception:
-        # If button not found, the home page might not have loaded properly
-        logger.warning("Time button not found on first attempt")
-
-        # Try scrolling to find the button
-        await driver.evaluate("window.scrollTo(0, document.body.scrollHeight)")
-        await driver.wait_for_timeout(1000)
-
-        # Try again with shorter timeout
-        await time_button.wait_for(timeout=ELEMENT_TIMEOUT, state="visible")
-
-    logger.info("Clicking Time button...")
-    await time_button.click()
+    # Find and click the "Time" link in the revealed submenu
+    time_link = driver.get_by_role("link", name="Time", exact=True)
+    await time_link.wait_for(state="visible", timeout=ELEMENT_TIMEOUT)
+    logger.info("Clicking Time link...")
+    await time_link.click()
 
     # Wait for navigation to complete
     await driver.wait_for_load_state("domcontentloaded")

--- a/tests/e2e/mock_servers/templates/workday_home.html
+++ b/tests/e2e/mock_servers/templates/workday_home.html
@@ -7,23 +7,61 @@
 <body>
   <header>
     <h1>Workday</h1>
+    <nav aria-label="Workday Global Navigation">
+      <ul>
+        <li><a href="/d/pex/home.htmld">Home</a></li>
+        <li><button type="button">Organization</button></li>
+        <li>
+          <!-- Personal nav button with hover submenu -->
+          <!-- Matches: get_by_role("button", name="Personal", exact=True) -->
+          <button type="button" id="personal-btn"
+            onmouseenter="showPersonalMenu()"
+            onmouseleave="hidePersonalMenuDelayed()">
+            Personal
+          </button>
+          <ul id="personal-menu" style="display:none"
+            onmouseenter="cancelHidePersonalMenu()"
+            onmouseleave="hidePersonalMenu()">
+            <li><a href="#">Talent and Performance</a></li>
+            <!-- Matches: get_by_role("link", name="Time", exact=True) -->
+            <li><a href="/d/time.htmld">Time</a></li>
+            <li><a href="#">Absence</a></li>
+            <li><a href="#">Career Hub</a></li>
+          </ul>
+        </li>
+        <li><button type="button">More</button></li>
+      </ul>
+    </nav>
   </header>
 
   <main>
-    <section aria-label="Your Top Apps">
-      <h2>Your Top Apps</h2>
-      <div class="app-grid">
-        <!-- Matches: get_by_role("button", name="Time", exact=True) -->
-        <button type="button"
-          onclick="window.location='/d/time.htmld'">
-          Time
-        </button>
-
-        <!-- Other apps for realism -->
-        <button type="button">Benefits</button>
-        <button type="button">Pay</button>
-      </div>
+    <section>
+      <h1>Let's Get Started</h1>
+      <input type="search" aria-label="Search Workday" role="combobox" />
+      <ul aria-label="Quick Actions">
+        <li><button type="button">My Org Chart</button></li>
+        <li><button type="button">Request Absence</button></li>
+        <li><button type="button">Time Off Balance</button></li>
+        <li><button type="button">Feedback Received</button></li>
+      </ul>
     </section>
   </main>
+
+  <script>
+    let hideTimer = null;
+    function showPersonalMenu() {
+      if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
+      document.getElementById('personal-menu').style.display = 'block';
+    }
+    function hidePersonalMenu() {
+      document.getElementById('personal-menu').style.display = 'none';
+    }
+    function hidePersonalMenuDelayed() {
+      hideTimer = setTimeout(hidePersonalMenu, 200);
+    }
+    function cancelHidePersonalMenu() {
+      if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
+    }
+  </script>
 </body>
 </html>

--- a/tests/unit/workday/fakes.py
+++ b/tests/unit/workday/fakes.py
@@ -52,6 +52,9 @@ class FakeLocator:
         if self.click_callback:
             self.click_callback()
 
+    async def hover(self) -> None:
+        """Hover over the element - no-op in fake."""
+
     async def fill(self, value: str) -> None:
         """Fill the element - calls callback if configured."""
         if self.fill_callback:

--- a/tests/unit/workday/test_scraping.py
+++ b/tests/unit/workday/test_scraping.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import re
 from datetime import date
 from typing import ClassVar
@@ -439,12 +438,19 @@ class TestNavigateToTimePage:
 
     @pytest.mark.asyncio
     async def test_navigate_to_time_page_success(self) -> None:
-        """Test successful navigation to time page."""
+        """Test successful navigation to time page via Personal submenu hover."""
         driver = FakeBrowserDriver()
 
-        # Configure Time button
+        # Configure Personal button (hover reveals submenu)
         driver.configure_locator(
             role="button",
+            name="Personal",
+            text_content="Personal",
+        )
+
+        # Configure Time link in the Personal submenu
+        driver.configure_locator(
+            role="link",
             name="Time",
             text_content="Time",
         )
@@ -470,45 +476,6 @@ class TestNavigateToTimePage:
         )
 
         await navigate_to_time_page(driver, date(2025, 4, 15))
-
-    @pytest.mark.asyncio
-    async def test_navigate_to_time_page_with_scroll(self) -> None:
-        """Test navigation when Time button not initially visible."""
-        driver = FakeBrowserDriver()
-
-        # Configure Time button that fails first wait_for, succeeds second
-        time_button = driver.configure_locator(
-            role="button",
-            name="Time",
-            text_content="Time",
-        )
-        # First wait_for raises, second succeeds
-        time_button.wait_for_raises = TimeoutError("Button not found")
-
-        # After evaluate (scroll), create new button that works
-        driver.configure_locator(
-            role="button",
-            name="Time",
-            text_content="Time",
-        )
-
-        # Configure rest of the flow
-        driver.configure_locator(role="link", name=re.compile(r"Select Week"))
-        driver.configure_locator(role="spinbutton", name="Month")
-        driver.configure_locator(role="spinbutton", name="Day")
-        driver.configure_locator(role="spinbutton", name="Year")
-        driver.configure_locator(role="button", name="OK")
-        driver.configure_locator(
-            role="heading",
-            name=re.compile(r"\w+ \d+.*\d{4}"),
-            level=2,
-            text_content="Apr 14 - 20, 2025",
-        )
-
-        # This should handle the scroll fallback
-        with contextlib.suppress(TimeoutError):
-            # Expected since our fake doesn't perfectly simulate the retry
-            await navigate_to_time_page(driver, date(2025, 4, 15))
 
 
 class TestSelectWeekViaModal:


### PR DESCRIPTION
## Summary

Fixes #50

The Workday home page layout changed. The **Time** button was removed from the top-level sidebar navigation and is now a **link** inside the **Personal** hover submenu.

### Root Cause

The code at `scraping.py` was looking for:
```python
get_by_role("button", name="Time", exact=True)
```

But Workday changed the layout so the sidebar now has: Home → Organization → Personal → More — with no direct "Time" button. Time is now accessible by hovering over "Personal", which reveals a submenu with a "Time" link.

### Fix

**New navigation flow:**
1. Wait for the "Personal" button to be visible in the sidebar
2. Hover over "Personal" to reveal the submenu  
3. Click the "Time" link in the submenu
4. Continue with the existing "Select Week" modal flow (unchanged)

### Changes

| File | Change |
|------|--------|
| `src/iptax/workday/scraping.py` | Replace Time button click with Personal hover + Time link click |
| `src/iptax/workday/protocols.py` | Add `hover()` to `LocatorProtocol` |
| `src/iptax/workday/driver.py` | Implement `hover()` in `PlaywrightLocator` |
| `tests/unit/workday/fakes.py` | Add `hover()` no-op to `FakeLocator` |
| `tests/e2e/mock_servers/templates/workday_home.html` | Update mock to match new sidebar layout with Personal submenu |
| `tests/unit/workday/test_scraping.py` | Update `TestNavigateToTimePage` tests for new flow |

Assisted-by: 🤖 Claude Opus/Sonnet 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Workday navigation to hover over the Personal menu and click the Time link after Workday moved Time into a submenu. Adds hover support to the locator API; tests and mocks updated; the Select Week flow stays the same.

- **Bug Fixes**
  - In `scraping.py`, hover "Personal" then click the "Time" link (removed scroll-based fallback for a missing button).
  - In `protocols.py` and `driver.py`, add and implement `hover()` on `LocatorProtocol` and `PlaywrightLocator`.
  - Update tests and mocks to match the new sidebar layout; add `hover()` no-op to `FakeLocator`.

- **Migration**
  - If you implement `LocatorProtocol` outside this repo, add a `hover()` method.

<sup>Written for commit eb39d31c89a97b450afb24d9107e5c6d13086d51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hover interaction capability for web element interactions

* **Refactor**
  * Updated Workday Time page navigation to access through a Personal menu hover pattern, replacing direct button access and scroll-based fallback logic

* **Tests**
  * Updated navigation tests to reflect new Personal menu interaction pattern; removed obsolete scroll fallback test case

<!-- end of auto-generated comment: release notes by coderabbit.ai -->