### PR TITLE
Handle hamburger menu when Workday sidebar is hidden

### DIFF
--- a/src/iptax/workday/driver.py
+++ b/src/iptax/workday/driver.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+
 from iptax.workday.protocols import (
     KeyboardProtocol,
     LocatorProtocol,
@@ -38,12 +40,19 @@ class PlaywrightLocator:
         state: str = "visible",
         timeout: int | None = None,
     ) -> None:
-        """Wait for element to reach specified state."""
-        # Cast to expected literal type for Playwright API
-        await self._locator.wait_for(
-            state=cast(Literal["attached", "detached", "hidden", "visible"], state),
-            timeout=timeout,
-        )
+        """Wait for element to reach specified state.
+
+        Translates Playwright's TimeoutError to the built-in TimeoutError so
+        callers can catch TimeoutError without importing Playwright internals.
+        """
+        try:
+            # Cast to expected literal type for Playwright API
+            await self._locator.wait_for(
+                state=cast(Literal["attached", "detached", "hidden", "visible"], state),
+                timeout=timeout,
+            )
+        except PlaywrightTimeoutError as exc:
+            raise TimeoutError(str(exc)) from exc
 
     async def click(self) -> None:
         """Click the element."""

--- a/src/iptax/workday/scraping.py
+++ b/src/iptax/workday/scraping.py
@@ -65,9 +65,6 @@ async def navigate_to_time_page(
     personal_button = driver.get_by_role("button", name="Personal", exact=True)
     try:
         await personal_button.wait_for(state="visible", timeout=_NAV_LAYOUT_TIMEOUT)
-        # Sidebar is visible: hover Personal to reveal submenu, then click Time
-        logger.info("Sidebar detected — hovering Personal to reveal submenu...")
-        await personal_button.hover()
     except Exception:
         # Sidebar is hidden: click the MENU hamburger button to open nav dialog
         logger.info("No sidebar — using MENU button fallback...")
@@ -75,6 +72,10 @@ async def navigate_to_time_page(
         await menu_button.wait_for(state="visible", timeout=ELEMENT_TIMEOUT)
         await menu_button.click()
         logger.info("Opened MENU navigation dialog...")
+    else:
+        # Sidebar is visible: hover Personal to reveal submenu, then click Time
+        logger.info("Sidebar detected — hovering Personal to reveal submenu...")
+        await personal_button.hover()
 
     # In both layouts, "Time" is now a visible link (sidebar submenu or dialog)
     time_link = driver.get_by_role("link", name="Time", exact=True)

--- a/src/iptax/workday/scraping.py
+++ b/src/iptax/workday/scraping.py
@@ -29,6 +29,12 @@ logger = logging.getLogger(__name__)
 ProgressCallback = Callable[[str], None] | None
 
 
+# Short timeout for sidebar/hamburger detection after page load is confirmed.
+# At this point the SPA has loaded (Search box visible), so the nav layout
+# is already determined — we just need a short window to check.
+_NAV_LAYOUT_TIMEOUT = 3000  # 3 seconds
+
+
 async def navigate_to_time_page(
     driver: BrowserDriverProtocol, target_date: date
 ) -> None:
@@ -37,22 +43,40 @@ async def navigate_to_time_page(
     Uses the "Select Week" option to jump directly to the target date,
     which is much faster than navigating week by week.
 
-    The Workday home page now places "Time" under the "Personal" submenu,
-    which appears on hover. We hover over "Personal" then click "Time".
+    Supports two Workday home page layouts:
+    - **Sidebar visible (default):** hover over "Personal" → click "Time" link
+    - **Sidebar hidden (user preference):** click "MENU" button → click "Time"
+
+    The user can toggle the sidebar via Workday Customize → "Always Show Sidebar".
 
     Args:
         driver: Browser driver object
         target_date: The target date to navigate to
     """
-    logger.info("Looking for Time link under Personal submenu...")
+    # Wait for the SPA to finish loading — "Search Workday" is always present
+    # in both sidebar and hamburger layouts once the home page is ready.
+    logger.info("Waiting for Workday home page to load...")
+    search_box = driver.get_by_role("combobox", name="Search Workday")
+    await search_box.wait_for(state="visible", timeout=ELEMENT_TIMEOUT)
+    logger.info("Home page loaded, detecting navigation layout...")
 
-    # Hover over the "Personal" nav button to reveal submenu
+    # Detect layout: sidebar (Personal button) or hamburger (MENU button).
+    # Now that page is confirmed loaded, a short timeout is safe.
     personal_button = driver.get_by_role("button", name="Personal", exact=True)
-    await personal_button.wait_for(state="visible", timeout=ELEMENT_TIMEOUT)
-    await personal_button.hover()
-    logger.info("Hovered over Personal button, looking for Time link...")
+    try:
+        await personal_button.wait_for(state="visible", timeout=_NAV_LAYOUT_TIMEOUT)
+        # Sidebar is visible: hover Personal to reveal submenu, then click Time
+        logger.info("Sidebar detected — hovering Personal to reveal submenu...")
+        await personal_button.hover()
+    except Exception:
+        # Sidebar is hidden: click the MENU hamburger button to open nav dialog
+        logger.info("No sidebar — using MENU button fallback...")
+        menu_button = driver.get_by_role("button", name="MENU", exact=True)
+        await menu_button.wait_for(state="visible", timeout=ELEMENT_TIMEOUT)
+        await menu_button.click()
+        logger.info("Opened MENU navigation dialog...")
 
-    # Find and click the "Time" link in the revealed submenu
+    # In both layouts, "Time" is now a visible link (sidebar submenu or dialog)
     time_link = driver.get_by_role("link", name="Time", exact=True)
     await time_link.wait_for(state="visible", timeout=ELEMENT_TIMEOUT)
     logger.info("Clicking Time link...")

--- a/src/iptax/workday/scraping.py
+++ b/src/iptax/workday/scraping.py
@@ -65,7 +65,7 @@ async def navigate_to_time_page(
     personal_button = driver.get_by_role("button", name="Personal", exact=True)
     try:
         await personal_button.wait_for(state="visible", timeout=_NAV_LAYOUT_TIMEOUT)
-    except Exception:
+    except TimeoutError:
         # Sidebar is hidden: click the MENU hamburger button to open nav dialog
         logger.info("No sidebar — using MENU button fallback...")
         menu_button = driver.get_by_role("button", name="MENU", exact=True)
@@ -115,7 +115,7 @@ async def select_week_via_modal(
     select_week_link = driver.get_by_role("link", name=re.compile(r"Select Week"))
     try:
         await select_week_link.wait_for(state="visible", timeout=ELEMENT_TIMEOUT)
-    except Exception:
+    except TimeoutError:
         # Maybe it's visible as a button instead
         select_week_link = driver.get_by_role("button", name=re.compile(r"Select Week"))
         await select_week_link.wait_for(state="visible", timeout=ELEMENT_TIMEOUT)

--- a/tests/unit/workday/test_driver.py
+++ b/tests/unit/workday/test_driver.py
@@ -6,6 +6,7 @@ import re
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 
 from iptax.workday.driver import (
     PlaywrightDriver,
@@ -27,6 +28,16 @@ class TestPlaywrightLocator:
         await wrapper.wait_for(state="visible", timeout=5000)
 
         mock_locator.wait_for.assert_called_once_with(state="visible", timeout=5000)
+
+    @pytest.mark.asyncio
+    async def test_wait_for_translates_playwright_timeout_to_builtin(self) -> None:
+        """Test wait_for translates Playwright TimeoutError to built-in TimeoutError."""
+        mock_locator = AsyncMock()
+        mock_locator.wait_for.side_effect = PlaywrightTimeoutError("timed out")
+        wrapper = PlaywrightLocator(mock_locator)
+
+        with pytest.raises(TimeoutError):
+            await wrapper.wait_for(state="visible", timeout=100)
 
     @pytest.mark.asyncio
     async def test_click(self) -> None:

--- a/tests/unit/workday/test_scraping.py
+++ b/tests/unit/workday/test_scraping.py
@@ -436,10 +436,30 @@ class TestWaitForWeekChange:
 class TestNavigateToTimePage:
     """Test navigate_to_time_page function."""
 
+    def _configure_rest_of_flow(self, driver: FakeBrowserDriver) -> None:
+        """Configure Select Week modal and heading locators (shared between tests)."""
+        driver.configure_locator(
+            role="link",
+            name=re.compile(r"Select Week"),
+        )
+        driver.configure_locator(role="spinbutton", name="Month")
+        driver.configure_locator(role="spinbutton", name="Day")
+        driver.configure_locator(role="spinbutton", name="Year")
+        driver.configure_locator(role="button", name="OK")
+        driver.configure_locator(
+            role="heading",
+            name=re.compile(r"\w+ \d+.*\d{4}"),
+            level=2,
+            text_content="Apr 14 - 20, 2025",
+        )
+
     @pytest.mark.asyncio
-    async def test_navigate_to_time_page_success(self) -> None:
-        """Test successful navigation to time page via Personal submenu hover."""
+    async def test_navigate_to_time_page_sidebar_layout(self) -> None:
+        """Test successful navigation via Personal submenu hover (sidebar visible)."""
         driver = FakeBrowserDriver()
+
+        # Page load gate: Search Workday combobox is always present on home page
+        driver.configure_locator(role="combobox", name="Search Workday")
 
         # Configure Personal button (hover reveals submenu)
         driver.configure_locator(
@@ -455,26 +475,40 @@ class TestNavigateToTimePage:
             text_content="Time",
         )
 
-        # Configure Select Week link
+        self._configure_rest_of_flow(driver)
+        await navigate_to_time_page(driver, date(2025, 4, 15))
+
+    @pytest.mark.asyncio
+    async def test_navigate_to_time_page_hamburger_layout(self) -> None:
+        """Test navigation via MENU button when sidebar is hidden."""
+        driver = FakeBrowserDriver()
+
+        # Page load gate: Search Workday combobox is always present on home page
+        driver.configure_locator(role="combobox", name="Search Workday")
+
+        # Personal button not present (sidebar hidden) — wait_for times out
+        personal_button = driver.configure_locator(
+            role="button",
+            name="Personal",
+            text_content="Personal",
+        )
+        personal_button.wait_for_raises = TimeoutError("No sidebar")
+
+        # MENU (hamburger) button is present instead
+        driver.configure_locator(
+            role="button",
+            name="MENU",
+            text_content="MENU",
+        )
+
+        # Time link is visible in the opened MENU dialog
         driver.configure_locator(
             role="link",
-            name=re.compile(r"Select Week"),
+            name="Time",
+            text_content="Time",
         )
 
-        # Configure date inputs
-        driver.configure_locator(role="spinbutton", name="Month")
-        driver.configure_locator(role="spinbutton", name="Day")
-        driver.configure_locator(role="spinbutton", name="Year")
-        driver.configure_locator(role="button", name="OK")
-
-        # Configure week heading for verification
-        driver.configure_locator(
-            role="heading",
-            name=re.compile(r"\w+ \d+.*\d{4}"),
-            level=2,
-            text_content="Apr 14 - 20, 2025",
-        )
-
+        self._configure_rest_of_flow(driver)
         await navigate_to_time_page(driver, date(2025, 4, 15))
 
 


### PR DESCRIPTION
## Summary

Fixes #52

When users uncheck **"Always Show Sidebar"** in Workday's Customize Navigation, the sidebar is hidden and replaced by a hamburger **MENU** button in the header. The previous code always tried to hover over the  sidebar button, which didn't exist in this layout.

## Root Cause

Workday offers two navigation layouts (user-configurable):

| Layout | Sidebar setting | Navigation |
|--------|----------------|-----------|
| Sidebar visible (default) | Always Show Sidebar ✅ | Hover `Personal` → click `Time` link |
| Sidebar hidden | Always Show Sidebar ☐ | Click `MENU` → click `Time` link in dialog |

## Fix

In `navigate_to_time_page()`:
1. **Page load gate:** Wait for `combobox "Search Workday"` to be visible — this is present in **both** layouts once the SPA finishes loading (avoids false negatives from auth delays)
2. **Layout detection:** With a short 3-second timeout (safe since page is confirmed loaded), try to find the `Personal` sidebar button
3. **Sidebar path:** If found → hover to reveal submenu
4. **Hamburger path:** If not found → click `MENU` button to open navigation dialog  
5. **Common path:** Click `Time` link (visible in both layouts), continue with existing Select Week flow

## Changes

| File | Change |
|------|--------|
| `src/iptax/workday/scraping.py` | Add Search Workday page-load gate; add MENU fallback after layout detection |
| `tests/unit/workday/test_scraping.py` | Add Search Workday combobox to sidebar test; add new hamburger layout test |

Assisted-by: 🤖 Claude Opus/Sonnet 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Workday navigation when users hide the sidebar: `navigate_to_time_page` now detects the layout and uses the header MENU if needed, and timeout handling uses the built-in `TimeoutError`. Fixes #52.

- **Bug Fixes**
  - Wait for the "Search Workday" combobox to confirm the home page is loaded.
  - Detect sidebar vs. hamburger with a 3s check; hover Personal or click MENU. Use try/except/else so fallback only triggers when the sidebar is missing.
  - Translate `Playwright` `TimeoutError` to built-in `TimeoutError` in `PlaywrightLocator.wait_for()`, and narrow catches in scraping to `TimeoutError` (including `select_week_via_modal`).
  - Update existing test and add a new test for the hamburger layout; add a test for timeout translation.

<sup>Written for commit be750ddd04b352eb606ad50c6c84d71f2895f883. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of navigating to the Time page by better detecting different Workday layouts (sidebar vs menu) and waiting for the page to be ready; standardized timeout behavior for locator waits.

* **Tests**
  * Added and refactored tests to cover both sidebar and hamburger layouts and to verify timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->