### PR TITLE
deps: switch did to PyPI 0.23.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,8 @@ AGENTS.md
 CLAUDE.md
 .claude/
 .make/
+.ai/
+.playwright-mcp/
 *.pdf
 *.docx
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,17 @@
 # Usage:
 #   docker build -t iptax-test . && docker run -it iptax-test
 #
-# PyPI release pending did PR #311. Until then, install from source.
+# Install iptax from PyPI (did PR #311 merged, released as did 0.23.1)
 
 FROM registry.access.redhat.com/ubi10/python-312-minimal:latest
 
 # Install required system dependencies:
-# - git: for pip git+https:// installs
 # - krb5-devel, gcc, python3-devel: for gssapi build
 #   (required by did -> requests-gssapi)
 # - pango, cairo, gdk-pixbuf2, fontconfig: for WeasyPrint PDF generation
 USER root
 RUN microdnf install -y \
-        git krb5-devel gcc python3-devel \
+        krb5-devel gcc python3-devel \
         pango cairo gdk-pixbuf2 fontconfig \
     && microdnf clean all
 USER 1001
@@ -24,9 +23,8 @@ RUN pip install pipx && \
 
 ENV PATH="/opt/app-root/src/.local/bin:$PATH"
 
-# Install iptax from git source (PyPI blocked until did PR #311 merges)
-# After PyPI release, change to: pipx install iptax
-RUN pipx install git+https://github.com/cardil/iptax.git
+# Install iptax from PyPI
+RUN pipx install iptax
 
 # Verify installation
 RUN iptax --help

--- a/README.md
+++ b/README.md
@@ -58,32 +58,17 @@ brew install pango gdk-pixbuf gtk+3 dbus krb5
 
 ### Using pipx (Recommended)
 
-> **Note:** PyPI release pending [did PR #311](https://github.com/psss/did/pull/311)
-> merge. Until then, install from source.
-
 ```bash
-# After PyPI release:
 pipx install iptax
-
-# Until then, install from source:
-pipx install git+https://github.com/cardil/iptax.git
 ```
 
 ### Using uvx (No Install)
 
 Run directly without installation:
 
-> **Note:** PyPI release pending [did PR #311](https://github.com/psss/did/pull/311)
-> merge. Until then, install from source.
-
 ```bash
-# After PyPI release:
 uvx iptax config
 uvx iptax
-
-# Until then, install from source:
-uvx --from git+https://github.com/cardil/iptax.git iptax config
-uvx --from git+https://github.com/cardil/iptax.git iptax
 ```
 
 ### From Source (Development)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,7 @@ See [`pyproject.toml`](../pyproject.toml:1) for the complete dependency list.
 - **HTTP Client:** `httpx>=0.25.0`
 - **Date/Time:** `python-dateutil>=2.8.2`
 - **Markdown:** `markdown>=3.5.0`
-- **did Integration:** `did @ git+https://github.com/psss/did.git@refs/pull/311/head`
+- **did Integration:** `did>=0.23.0`
 
 ### Project Structure
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -97,8 +97,8 @@ Generate monthly IP tax reports for the Polish IP tax deduction program by:
 
 #### psss/did Integration
 
-**Repository:** [psss/did](https://github.com/psss/did) **Version Required:** PR #311
-(until merged into main)
+**Repository:** [psss/did](https://github.com/psss/did) **Version Required:** >=0.23.0
+(PR #311 merged into main on 2026-03-27, released as 0.23.1 on 2026-03-30)
 
 **Purpose:** Fetch merged PRs/MRs from GitHub/GitLab instances.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ dependencies = [
     # Data validation
     "pydantic>=2.5.0",
 
-    # Did integration (PR/MR fetching) - using PR #311
-    "did @ git+https://github.com/psss/did.git@refs/pull/311/head",
+    # Did integration (PR/MR fetching)
+    "did>=0.23.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.lock
+++ b/requirements.lock
@@ -6,6 +6,7 @@ anyio==4.12.0
 argcomplete==3.6.3
 asttokens==3.0.1
 attrs==25.4.0
+backports.tarfile==1.2.0
 black==25.12.0
 blinker==1.9.0
 brotli==1.2.0
@@ -24,7 +25,7 @@ cssselect2==0.8.0
 decli==0.6.3
 decorator==5.2.1
 Deprecated==1.3.1
-did @ git+https://github.com/psss/did.git@ae4b8d04b84f300725a3da98f0c1cb9da577a1d0
+did==0.23.1
 distro==1.9.0
 docutils==0.22.3
 dotty-dict==1.3.1
@@ -153,7 +154,6 @@ ruamel.yaml==0.18.16
 ruamel.yaml.clib==0.2.15
 ruff==0.14.8
 SecretStorage==3.5.0
-setuptools==80.9.0
 shellingham==1.5.4
 six==1.17.0
 smmap==5.0.2
@@ -183,7 +183,6 @@ wcwidth==0.2.14
 weasyprint==67.0
 webencodings==0.5.1
 Werkzeug==3.1.4
-wheel==0.45.1
 wrapt==2.0.1
 yarl==1.22.0
 zipp==3.23.0


### PR DESCRIPTION
## Summary

PR #311 ("Support `merged` pull requests for `github` and `gitlab`") was merged on 2026-03-27 and released as `did 0.23.1` on 2026-03-30.

## Changes

- **`pyproject.toml`**: Replace `did @ git+https://...@refs/pull/311/head` with `did>=0.23.0` (PyPI)
- **`README.md`**: Remove "PyPI release pending" notes from `pipx` and `uvx` installation sections
- **`docs/requirements.md`**: Update version requirement note (PR #311 now merged and released)
- **`requirements.lock`**: Updated from git ref to `did==0.23.1`
- **`.gitignore`**: Add `.playwright-mcp/` and `.ai/` to gitignore

## Testing

All checks pass: 883 unit tests + 11 e2e tests ✅

Assisted-by: 🤖 Claude Sonnet 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `did` from a Git PR ref to the PyPI release and update the container and docs to use PyPI installs. Aligns with PR #311 released as `did 0.23.1` to simplify builds and installs.

- **Dependencies**
  - Replaced `did @ git+https://...@refs/pull/311/head` with `did>=0.23.0` in `pyproject.toml`.
  - Pinned `requirements.lock` to `did==0.23.1`.

- **Build & Docs**
  - Dockerfile: install `iptax` via `pipx install iptax` and remove `git` from system deps.
  - Updated `docs/architecture.md` to `did>=0.23.0`.
  - Removed "PyPI release pending" notes from `README`.
  - Updated `docs/requirements.md` to require `did >= 0.23.0` with release details.
  - Ignored `.ai/` and `.playwright-mcp/` in `.gitignore`.

<sup>Written for commit a8b55050b2b63b9c86bcbe928d499fa0d83107eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified README by removing temporary install-from-source guidance.
  * Updated integration requirements to use a concrete released minimum version and release timing details.

* **Chores**
  * Switched dependency reference to a released package constraint.
  * Updated ignore patterns to exclude additional development directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->