### PR TITLE
fix: allow zero-change reports and detect Did provider errors

### DIFF
--- a/src/iptax/cache/inflight.py
+++ b/src/iptax/cache/inflight.py
@@ -59,8 +59,8 @@ class ReportState:
         Returns:
             ReportState with derived states and status
         """
-        # Did collection state
-        did = STATE_COMPLETE if report.changes else STATE_PENDING
+        # Did collection state (based on whether collection ran, not change count)
+        did = STATE_COMPLETE if report.did_collected else STATE_PENDING
 
         # Workday collection state
         if report.total_hours is not None:

--- a/src/iptax/cli/flows.py
+++ b/src/iptax/cli/flows.py
@@ -283,6 +283,61 @@ async def review(
 MIN_WORK_HOURS = 0.5
 
 
+def _handle_existing_inflight(
+    console: Console,
+    cache: InFlightCache,
+    month_key: str,
+    force: bool,
+) -> bool:
+    """Handle existing in-flight report (discard if forced, reject otherwise).
+
+    Returns:
+        True if should proceed, False if blocked by existing report.
+    """
+    if force and cache.exists(month_key):
+        console.print(
+            f"[yellow]🗑[/yellow] Discarding existing in-flight for {month_key}"
+        )
+        cache.delete(month_key)
+        return True
+
+    if cache.exists(month_key):
+        existing_report = cache.load(month_key)
+        console.print(f"\n[red]✗[/red] In-flight report already exists for {month_key}")
+        if existing_report:
+            _display_inflight_summary(console, existing_report)
+        console.print("\nUse --force to discard and start fresh")
+        return False
+
+    return True
+
+
+def _confirm_zero_changes(console: Console) -> bool:
+    """Warn about zero changes and ask user to confirm.
+
+    Args:
+        console: Rich console for output
+
+    Returns:
+        True if should proceed, False if user declined.
+    """
+    console.print(
+        "\n[yellow]⚠ WARNING:[/yellow] " "No code changes found for this period."
+    )
+    if console.is_terminal:
+        if not Confirm.ask(
+            "[bold]Continue with a zero-change report?[/bold]",
+            default=True,
+        ):
+            console.print("[yellow]⏹[/yellow] Aborted by user")
+            return False
+    else:
+        console.print(
+            "[yellow]⚠[/yellow] Continuing with zero changes " "(non-interactive mode)"
+        )
+    return True
+
+
 async def _fetch_workday_data(
     console: Console,
     report: InFlightReport,
@@ -409,17 +464,7 @@ async def collect_flow(
 
     # Check for existing in-flight
     cache = InFlightCache()
-    if options.force and cache.exists(month_key):
-        console.print(
-            f"[yellow]🗑[/yellow] Discarding existing in-flight for {month_key}"
-        )
-        cache.delete(month_key)
-    elif cache.exists(month_key):
-        existing_report = cache.load(month_key)
-        console.print(f"\n[red]✗[/red] In-flight report already exists for {month_key}")
-        if existing_report:
-            _display_inflight_summary(console, existing_report)
-        console.print("\nUse --force to discard and start fresh")
+    if not _handle_existing_inflight(console, cache, month_key, options.force):
         return False
 
     # Create in-flight report
@@ -439,6 +484,9 @@ async def collect_flow(
         )
         changes = fetch_changes(console, settings, ranges.did_start, ranges.did_end)
         report.changes = changes
+
+        if not changes and not _confirm_zero_changes(console):
+            return False
     else:
         console.print("[yellow]⏭[/yellow] Skipping Did collection")
 
@@ -665,12 +713,12 @@ def _resolve_review_month(
     return None
 
 
-def _load_report_for_review(
+def _load_report(
     console: Console,
     cache: InFlightCache,
     month: str | None,
 ) -> tuple[InFlightReport | None, str | None]:
-    """Load and validate report for review.
+    """Load report from cache without checking for changes.
 
     Args:
         console: Rich console for output
@@ -701,6 +749,29 @@ def _load_report_for_review(
 
     if report is None:
         console.print(f"[red]✗[/red] Failed to load report for {month_key}")
+        return None, None
+
+    return report, month_key
+
+
+def _load_report_for_review(
+    console: Console,
+    cache: InFlightCache,
+    month: str | None,
+) -> tuple[InFlightReport | None, str | None]:
+    """Load and validate report for review (requires changes to be present).
+
+    Args:
+        console: Rich console for output
+        cache: In-flight cache manager
+        month: Month specification
+
+    Returns:
+        Tuple of (report, month_key) or (None, None) on failure
+    """
+    report, month_key = _load_report(console, cache, month)
+
+    if report is None:
         return None, None
 
     if not report.changes:
@@ -1037,36 +1108,36 @@ def _validate_dist_readiness(
     Returns:
         Error message if validation fails, None if successful
     """
-    if not report.changes:
-        return "No changes in report"
-
-    # Check review status - AI is disabled if it's DisabledAIConfig OR provider is None
-    ai_enabled = (
-        not isinstance(settings.ai, DisabledAIConfig)
-        and getattr(settings.ai, "provider", None) is not None
-    )
-
-    if ai_enabled:
-        # AI enabled: require judgments and all must be reviewed
-        if not report.judgments:
-            return (
-                "AI is enabled but no judgments found. "
-                "Run [cyan]iptax review[/cyan] first."
-            )
-
-        # Check if all judgments are reviewed
-        unreviewed = [j for j in report.judgments if j.user_decision is None]
-        if unreviewed:
-            return (
-                f"{len(unreviewed)} judgment(s) not reviewed. "
-                "Run [cyan]iptax review[/cyan] first."
-            )
-    elif not report.judgments and not force:
-        # AI disabled: require manual review confirmation
-        return (
-            "AI is disabled. Changes require manual review before generation.\n"
-            "Review your changes manually, then use --force to confirm and generate."
+    # When changes is empty, skip AI/judgment checks entirely -- zero-change months
+    # (e.g. full PTO) are valid and should compile to an empty report.
+    if report.changes:
+        # Check review status -- AI disabled if DisabledAIConfig OR provider is None
+        ai_enabled = (
+            not isinstance(settings.ai, DisabledAIConfig)
+            and getattr(settings.ai, "provider", None) is not None
         )
+
+        if ai_enabled:
+            # AI enabled: require judgments and all must be reviewed
+            if not report.judgments:
+                return (
+                    "AI is enabled but no judgments found. "
+                    "Run [cyan]iptax review[/cyan] first."
+                )
+
+            # Check if all judgments are reviewed
+            unreviewed = [j for j in report.judgments if j.user_decision is None]
+            if unreviewed:
+                return (
+                    f"{len(unreviewed)} judgment(s) not reviewed. "
+                    "Run [cyan]iptax review[/cyan] first."
+                )
+        elif not report.judgments and not force:
+            # AI disabled: require manual review confirmation
+            return (
+                "AI is disabled. Changes require manual review before generation.\n"
+                "Review your changes manually, then use --force to generate."
+            )
 
     # Check for required hours data (only if Workday is enabled)
     if report.total_hours is None and settings.workday.enabled:
@@ -1102,7 +1173,7 @@ async def dist_flow(
 
     # Load in-flight report
     cache = InFlightCache()
-    report, month_key = _load_report_for_review(console, cache, month)
+    report, month_key = _load_report(console, cache, month)
 
     if report is None:
         return False

--- a/src/iptax/cli/flows.py
+++ b/src/iptax/cli/flows.py
@@ -484,6 +484,7 @@ async def collect_flow(
         )
         changes = fetch_changes(console, settings, ranges.did_start, ranges.did_end)
         report.changes = changes
+        report.did_collected = True
 
         if not changes and not _confirm_zero_changes(console):
             return False

--- a/src/iptax/did.py
+++ b/src/iptax/did.py
@@ -9,6 +9,7 @@ import logging
 import re
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import date, datetime
+from types import TracebackType
 from typing import Literal, cast
 from urllib.parse import urlparse
 
@@ -23,6 +24,65 @@ logger = logging.getLogger(__name__)
 
 # Constants for stat detection
 MERGED_STAT_KEYWORDS = ("merged", "pull", "merge")
+
+# Regex to strip raw Future repr from did error messages
+_FUTURE_REPR_RE = re.compile(r"<Future at 0x[0-9a-fA-F]+ [^>]*>")
+
+
+class _DidErrorCapture:
+    """Context manager that captures ERROR-level log records from the 'did' logger."""
+
+    def __init__(self) -> None:
+        self._errors: list[str] = []
+        self._handler: logging.Handler | None = None
+
+    def __enter__(self) -> "_DidErrorCapture":
+        capture = self
+
+        class _Handler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                if record.levelno >= logging.ERROR:
+                    capture._errors.append(record.getMessage())
+
+        self._handler = _Handler()
+        logging.getLogger("did").addHandler(self._handler)
+        logging.getLogger().addHandler(self._handler)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        if self._handler is not None:
+            logging.getLogger("did").removeHandler(self._handler)
+            logging.getLogger().removeHandler(self._handler)
+            self._handler = None
+
+    def get_errors(self) -> list[str]:
+        return list(self._errors)
+
+
+_DUE_TO_SEPARATOR = "due to"
+
+
+def _clean_did_error_message(raw: str) -> str:
+    """Strip raw Future repr from a did error message, keeping the useful part."""
+    cleaned = _FUTURE_REPR_RE.sub("", raw)
+    parts = [p.strip() for p in cleaned.split(_DUE_TO_SEPARATOR) if p.strip()]
+    if len(parts) >= len(_DUE_TO_SEPARATOR.split()):
+        return parts[-1]
+    return " ".join(cleaned.split())
+
+
+def _raise_if_did_errors(errors: list[str], provider_name: str) -> None:
+    if not errors:
+        return
+    clean_messages = [_clean_did_error_message(e) for e in errors]
+    raise DidIntegrationError(
+        f"did provider '{provider_name}' reported errors: " + "; ".join(clean_messages)
+    )
 
 
 class DidIntegrationError(Exception):
@@ -120,15 +180,21 @@ def _fetch_provider_changes(
         stdout_capture = io.StringIO()
         stderr_capture = io.StringIO()
 
-        # Redirect both stdout and stderr
-        with redirect_stdout(stdout_capture), redirect_stderr(stderr_capture):
-            # Call did.cli.main() to get stats (POPOs)
+        # Redirect both stdout and stderr; also intercept did's logging errors
+        with (
+            redirect_stdout(stdout_capture),
+            redirect_stderr(stderr_capture),
+            _DidErrorCapture() as error_capture,
+        ):
             result = did.cli.main(option.split())
 
         # Check for errors in stderr
         _check_did_stderr(
             stderr_content=stderr_capture.getvalue(), provider_name=provider_name
         )
+
+        # Check for errors captured via logging
+        _raise_if_did_errors(error_capture.get_errors(), provider_name)
 
         # Log stdout output for debugging
         stdout_content = stdout_capture.getvalue()

--- a/src/iptax/did.py
+++ b/src/iptax/did.py
@@ -45,8 +45,10 @@ class _DidErrorCapture:
                     capture._errors.append(record.getMessage())
 
         self._handler = _Handler()
+        # Attach only to the "did" logger. With propagate=True (default),
+        # records from did.* children propagate up to "did", so this single
+        # attachment point catches all did-namespace errors without duplicates.
         logging.getLogger("did").addHandler(self._handler)
-        logging.getLogger().addHandler(self._handler)
         return self
 
     def __exit__(
@@ -57,7 +59,6 @@ class _DidErrorCapture:
     ) -> None:
         if self._handler is not None:
             logging.getLogger("did").removeHandler(self._handler)
-            logging.getLogger().removeHandler(self._handler)
             self._handler = None
 
     def get_errors(self) -> list[str]:

--- a/src/iptax/models.py
+++ b/src/iptax/models.py
@@ -877,6 +877,10 @@ class InFlightReport(BaseModel):
         default_factory=lambda: datetime.now(UTC),
         description="When this in-flight report was created (UTC)",
     )
+    did_collected: bool = Field(
+        default=False,
+        description="Whether Did collection was performed (even if zero changes)",
+    )
     changes: list[Change] = Field(
         default_factory=list,
         description="Did changes (PRs/MRs) collected",

--- a/src/iptax/models.py
+++ b/src/iptax/models.py
@@ -885,6 +885,14 @@ class InFlightReport(BaseModel):
         default_factory=list,
         description="Did changes (PRs/MRs) collected",
     )
+
+    @model_validator(mode="after")
+    def infer_did_collected_from_changes(self) -> "InFlightReport":
+        """Infer did_collected for legacy caches that predate the field."""
+        if not self.did_collected and self.changes:
+            self.did_collected = True
+        return self
+
     judgments: list[Judgment] = Field(
         default_factory=list,
         description="AI judgments for changes (empty until AI runs)",

--- a/src/iptax/models.py
+++ b/src/iptax/models.py
@@ -987,12 +987,12 @@ class ReportData(BaseModel):
     total_hours: int = Field(
         ...,
         description="Total working hours in period (rounded to whole hours)",
-        gt=0,
+        ge=0,
     )
     creative_hours: int = Field(
         ...,
         description="Creative work hours (calculated from total and percentage)",
-        gt=0,
+        ge=0,
     )
     creative_percentage: int = Field(
         ...,

--- a/src/iptax/report/compiler.py
+++ b/src/iptax/report/compiler.py
@@ -42,9 +42,6 @@ def compile_report(inflight: InFlightReport, settings: Settings) -> ReportData:
     if effective_hours is None:
         raise ValueError("Cannot compile report: effective_hours calculation failed")
 
-    if not inflight.changes:
-        raise ValueError("Cannot compile report: no changes found")
-
     # Build judgment lookup map
     judgment_map = {j.change_id: j for j in inflight.judgments}
 
@@ -79,12 +76,6 @@ def compile_report(inflight: InFlightReport, settings: Settings) -> ReportData:
         if judgment.final_decision == Decision.INCLUDE:
             included_changes.append(change)
         # EXCLUDE: skip (not an error)
-
-    if not included_changes:
-        raise ValueError(
-            "Cannot compile report: no changes were included after filtering. "
-            "Review judgments or add changes."
-        )
 
     # Extract unique repositories from included changes
     repo_map: dict[str, Repository] = {}

--- a/src/iptax/utils/logging.py
+++ b/src/iptax/utils/logging.py
@@ -83,7 +83,7 @@ def setup_logging(
 
     # Configure third-party loggers that add their own handlers
     # LiteLLM and related libs add StreamHandlers; redirect to our file handler
-    for logger_name in ("LiteLLM", "litellm", "httpx", "httpcore"):
+    for logger_name in ("LiteLLM", "litellm", "httpx", "httpcore", "did"):
         lib_logger = logging.getLogger(logger_name)
         # Remove any existing handlers (e.g., StreamHandlers to console)
         lib_logger.handlers.clear()

--- a/tests/unit/cache/test_inflight.py
+++ b/tests/unit/cache/test_inflight.py
@@ -287,6 +287,7 @@ class TestReportState:
             workday_end=date(2024, 11, 30),
             changes_since=date(2024, 10, 25),
             changes_until=date(2024, 11, 25),
+            did_collected=with_changes,
             changes=changes,
             total_hours=10.0 if with_total_hours else None,
             workday_validated=workday_validated,
@@ -380,6 +381,16 @@ class TestReportState:
         assert state.ai == STATE_COMPLETE
         assert state.reviewed == STATE_COMPLETE
         assert state.status == "Ready for dist"
+
+    @pytest.mark.unit
+    def test_zero_changes_did_collected_state(self) -> None:
+        """Test state when Did collected zero changes (PTO month)."""
+        report = self._create_report()
+        report.did_collected = True
+        state = ReportState.from_report(report)
+
+        assert state.did == STATE_COMPLETE
+        assert state.status != "Collecting"
 
     @pytest.mark.unit
     def test_workday_disabled(self) -> None:

--- a/tests/unit/cli/test_elements.py
+++ b/tests/unit/cli/test_elements.py
@@ -363,6 +363,7 @@ class TestDisplayInflightTable:
             workday_end=date(2024, 11, 30),
             changes_since=date(2024, 10, 25),
             changes_until=date(2024, 11, 25),
+            did_collected=with_changes,
             changes=changes,
             total_hours=total_hours,
             workday_validated=workday_validated,

--- a/tests/unit/cli/test_flows.py
+++ b/tests/unit/cli/test_flows.py
@@ -777,6 +777,7 @@ class TestCollectFlow:
         with (
             patch.object(flows, "config_load_settings", return_value=mock_settings),
             patch.object(flows, "did_fetch_changes", return_value=[]),
+            patch.object(flows, "_confirm_zero_changes", return_value=True),
             patch.object(flows, "InFlightCache") as mock_cache_cls,
         ):
             mock_cache = MagicMock()
@@ -836,6 +837,7 @@ class TestCollectFlow:
         with (
             patch.object(flows, "config_load_settings", return_value=mock_settings),
             patch.object(flows, "did_fetch_changes", return_value=[]),
+            patch.object(flows, "_confirm_zero_changes", return_value=True),
             patch.object(flows, "InFlightCache") as mock_cache_cls,
         ):
             mock_cache = MagicMock()
@@ -1072,6 +1074,7 @@ class TestReportFlow:
         with (
             patch.object(flows, "config_load_settings", return_value=mock_settings),
             patch.object(flows, "did_fetch_changes", return_value=[]),
+            patch.object(flows, "_confirm_zero_changes", return_value=True),
             patch.object(flows, "InFlightCache") as mock_cache_cls,
             patch.object(flows, "dist_flow", return_value=True),
             patch.object(flows, "save_report_date"),  # Prevent history leak
@@ -1693,11 +1696,13 @@ class TestDistFlow:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_no_changes_fails(self):
-        """Test that dist fails when no changes to report."""
+    async def test_no_changes_succeeds_when_hours_present(self, tmp_path):
+        """Test that dist succeeds with zero changes when hours data is present."""
         console = Console(file=StringIO(), force_terminal=True)
 
         mock_settings = MagicMock()
+        mock_settings.workday.enabled = False
+        mock_settings.ai.provider = None
 
         report = InFlightReport(
             month="2024-11",
@@ -1705,25 +1710,32 @@ class TestDistFlow:
             workday_end=date(2024, 11, 30),
             changes_since=date(2024, 10, 25),
             changes_until=date(2024, 11, 25),
-            changes=[],  # No changes
+            changes=[],
+            total_hours=168.0,
+            working_days=21,
+            absence_days=21,
         )
 
         with (
             patch.object(flows, "config_load_settings", return_value=mock_settings),
             patch.object(flows, "InFlightCache") as mock_cache_cls,
+            patch.object(flows, "compile_report") as mock_compile,
+            patch.object(flows, "generate_all") as mock_generate,
         ):
             mock_cache = MagicMock()
             mock_cache.list_all.return_value = ["2024-11"]
             mock_cache.load.return_value = report
             mock_cache_cls.return_value = mock_cache
 
+            mock_report_data = MagicMock()
+            mock_compile.return_value = mock_report_data
+            mock_generate.return_value = [tmp_path / "report.md"]
+
             result = await flows.dist_flow(
-                console, month="2024-11", output_options=OutputOptions()
+                console, month="2024-11", output_options=OutputOptions(), force=True
             )
 
-        assert result is False
-        output = strip_ansi(console.file.getvalue())
-        assert "No changes" in output
+        assert result is True
 
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -1853,6 +1865,119 @@ class TestDistFlow:
         assert result is False
         output = strip_ansi(console.file.getvalue())
         assert "Missing work hours data" in output
+
+
+class TestLoadReport:
+    """Tests for _load_report function."""
+
+    @pytest.mark.unit
+    def test_load_report_without_changes_check(self):
+        """Test that _load_report loads a report even when changes is empty."""
+        console = Console(file=StringIO(), force_terminal=True)
+
+        report = InFlightReport(
+            month="2024-11",
+            workday_start=date(2024, 11, 1),
+            workday_end=date(2024, 11, 30),
+            changes_since=date(2024, 10, 25),
+            changes_until=date(2024, 11, 25),
+            changes=[],  # No changes -- _load_report must NOT reject this
+        )
+
+        mock_cache = MagicMock(spec=InFlightCache)
+        mock_cache.list_all.return_value = ["2024-11"]
+        mock_cache.load.return_value = report
+
+        loaded_report, month_key = flows._load_report(console, mock_cache, "2024-11")
+
+        assert loaded_report is not None
+        assert month_key == "2024-11"
+        assert loaded_report.changes == []
+
+
+class TestValidateDistReadiness:
+    """Tests for _validate_dist_readiness function."""
+
+    @pytest.mark.unit
+    def test_validate_dist_readiness_accepts_zero_changes(self):
+        """Test that _validate_dist_readiness returns None when changes is empty."""
+        report = InFlightReport(
+            month="2024-11",
+            workday_start=date(2024, 11, 1),
+            workday_end=date(2024, 11, 30),
+            changes_since=date(2024, 10, 25),
+            changes_until=date(2024, 11, 25),
+            changes=[],
+            total_hours=160.0,
+            working_days=21,
+        )
+
+        mock_settings = MagicMock()
+        mock_settings.workday.enabled = False
+
+        result = flows._validate_dist_readiness(report, mock_settings, force=True)
+
+        assert result is None
+
+    @pytest.mark.unit
+    def test_validate_dist_readiness_still_requires_hours(self):
+        """Test that _validate_dist_readiness fails when hours are missing."""
+        report = InFlightReport(
+            month="2024-11",
+            workday_start=date(2024, 11, 1),
+            workday_end=date(2024, 11, 30),
+            changes_since=date(2024, 10, 25),
+            changes_until=date(2024, 11, 25),
+            changes=[],
+            total_hours=None,  # Missing hours
+        )
+
+        mock_settings = MagicMock()
+        mock_settings.workday.enabled = True
+
+        result = flows._validate_dist_readiness(report, mock_settings, force=True)
+
+        assert result is not None
+        assert "Missing work hours" in result
+
+
+class TestConfirmZeroChanges:
+    """Tests for _confirm_zero_changes function."""
+
+    @pytest.mark.unit
+    def test_confirms_when_user_accepts(self):
+        """Given TTY console, when user confirms, then returns True."""
+        console = Console(file=StringIO(), force_terminal=True)
+
+        with patch.object(Confirm, "ask", return_value=True):
+            result = flows._confirm_zero_changes(console)
+
+        assert result is True
+        output = strip_ansi(console.file.getvalue())
+        assert "No code changes found" in output
+
+    @pytest.mark.unit
+    def test_aborts_when_user_declines(self):
+        """Given TTY console, when user declines, then returns False."""
+        console = Console(file=StringIO(), force_terminal=True)
+
+        with patch.object(Confirm, "ask", return_value=False):
+            result = flows._confirm_zero_changes(console)
+
+        assert result is False
+        output = strip_ansi(console.file.getvalue())
+        assert "Aborted by user" in output
+
+    @pytest.mark.unit
+    def test_proceeds_in_non_interactive_mode(self):
+        """Given non-TTY console, then proceeds automatically."""
+        console = Console(file=StringIO(), force_terminal=False)
+
+        result = flows._confirm_zero_changes(console)
+
+        assert result is True
+        output = strip_ansi(console.file.getvalue())
+        assert "Continuing with zero changes" in output
 
 
 class TestConfirmOrForce:

--- a/tests/unit/report/test_compiler.py
+++ b/tests/unit/report/test_compiler.py
@@ -146,20 +146,6 @@ class TestCompileReport:
         with pytest.raises(ValueError, match="working_days is missing"):
             compile_report(basic_inflight, basic_settings)
 
-    def test_fails_with_no_changes(self, basic_inflight, basic_settings):
-        """Test that compilation succeeds with zero changes (full PTO month)."""
-        # 21 absence days * 8h = 168h total, effective_hours = 0
-        basic_inflight.changes = []
-        basic_inflight.total_hours = 168.0
-        basic_inflight.working_days = 21
-        basic_inflight.absence_days = 21
-
-        report = compile_report(basic_inflight, basic_settings)
-
-        assert report.changes == []
-        assert report.repositories == []
-        assert report.total_hours >= 0
-
     def test_compiles_with_zero_changes(self, basic_inflight, basic_settings):
         """Test that compilation succeeds with zero changes (full PTO month)."""
         # 21 absence days * 8h = 168h total, effective_hours = 0

--- a/tests/unit/report/test_compiler.py
+++ b/tests/unit/report/test_compiler.py
@@ -147,11 +147,62 @@ class TestCompileReport:
             compile_report(basic_inflight, basic_settings)
 
     def test_fails_with_no_changes(self, basic_inflight, basic_settings):
-        """Test that compilation fails if no changes exist."""
+        """Test that compilation succeeds with zero changes (full PTO month)."""
+        # 21 absence days * 8h = 168h total, effective_hours = 0
         basic_inflight.changes = []
+        basic_inflight.total_hours = 168.0
+        basic_inflight.working_days = 21
+        basic_inflight.absence_days = 21
 
-        with pytest.raises(ValueError, match="no changes found"):
-            compile_report(basic_inflight, basic_settings)
+        report = compile_report(basic_inflight, basic_settings)
+
+        assert report.changes == []
+        assert report.repositories == []
+        assert report.total_hours >= 0
+
+    def test_compiles_with_zero_changes(self, basic_inflight, basic_settings):
+        """Test that compilation succeeds with zero changes (full PTO month)."""
+        # 21 absence days * 8h = 168h total, effective_hours = 0
+        basic_inflight.changes = []
+        basic_inflight.total_hours = 168.0
+        basic_inflight.working_days = 21
+        basic_inflight.absence_days = 21
+
+        report = compile_report(basic_inflight, basic_settings)
+
+        assert report.changes == []
+        assert report.repositories == []
+        assert report.total_hours >= 0
+
+    def test_compiles_with_all_excluded_changes(
+        self, basic_inflight, basic_change, basic_settings
+    ):
+        """Test that compilation succeeds when all changes are excluded."""
+        judgment = Judgment(
+            change_id=basic_change.get_change_id(),
+            url=basic_change.get_url(),
+            description=basic_change.title,
+            decision=Decision.EXCLUDE,
+            reasoning="Not relevant to product",
+            product="Test Product",
+            ai_provider="gemini/gemini-2.5-pro",
+        )
+        basic_inflight.judgments = [judgment]
+
+        report = compile_report(basic_inflight, basic_settings)
+
+        assert report.changes == []
+
+    def test_zero_hours_report_compiles(self, basic_inflight, basic_settings):
+        """Test that a report with zero hours compiles (e.g. no working days)."""
+        basic_inflight.changes = []
+        basic_inflight.total_hours = 0.0
+        basic_inflight.working_days = 0
+        basic_inflight.absence_days = 0
+
+        report = compile_report(basic_inflight, basic_settings)
+
+        assert report.total_hours == 0
 
     def test_fails_with_missing_judgment_when_ai_enabled(
         self, basic_inflight, basic_settings
@@ -187,7 +238,7 @@ class TestCompileReport:
     def test_fails_with_no_included_changes(
         self, basic_inflight, basic_change, basic_settings
     ):
-        """Test that compilation fails if all changes are excluded."""
+        """Test compilation succeeds when all changes are excluded (empty result)."""
         judgment = Judgment(
             change_id=basic_change.get_change_id(),
             url=basic_change.get_url(),
@@ -199,8 +250,9 @@ class TestCompileReport:
         )
         basic_inflight.judgments = [judgment]
 
-        with pytest.raises(ValueError, match="no changes were included"):
-            compile_report(basic_inflight, basic_settings)
+        report = compile_report(basic_inflight, basic_settings)
+
+        assert report.changes == []
 
     def test_includes_only_accepted_changes(
         self, basic_inflight, github_repo, basic_settings
@@ -299,7 +351,7 @@ class TestCompileReport:
     def test_resolved_uncertain_judgment_with_exclude(
         self, basic_inflight, basic_change, basic_settings
     ):
-        """Test that resolved UNCERTAIN judgment (user=EXCLUDE) works."""
+        """Test that resolved UNCERTAIN judgment (user=EXCLUDE) yields empty changes."""
         judgment = Judgment(
             change_id=basic_change.get_change_id(),
             url=basic_change.get_url(),
@@ -313,8 +365,9 @@ class TestCompileReport:
         )
         basic_inflight.judgments = [judgment]
 
-        with pytest.raises(ValueError, match="no changes were included"):
-            compile_report(basic_inflight, basic_settings)
+        report = compile_report(basic_inflight, basic_settings)
+
+        assert report.changes == []
 
     def test_extracts_unique_repositories(
         self, basic_inflight, github_repo, gitlab_repo, basic_settings

--- a/tests/unit/test_did.py
+++ b/tests/unit/test_did.py
@@ -817,6 +817,99 @@ class TestCheckDidStderr:
         assert "github.com" in caplog.text
 
 
+class TestDidLoggingInterceptor:
+    """Test that did logging errors are captured and raised as DidIntegrationError."""
+
+    @patch("iptax.did.did.cli.main")
+    def test_error_log_during_did_call_raises_error(self, mock_did_main: Mock) -> None:
+        """Simulate did.cli.main() logging an ERROR -- assert error raised."""
+
+        def mock_did_main_with_error(*_args: object) -> tuple[list[object]]:
+            logging.getLogger("did").error(
+                "Skipping <Future at 0x123> due to "
+                "Unable to connect to 'https://gitlab.example.com'"
+            )
+            mock_user = Mock()
+            mock_user.stats = []
+            return ([mock_user],)
+
+        mock_did_main.side_effect = mock_did_main_with_error
+
+        with pytest.raises(DidIntegrationError):
+            _fetch_provider_changes(
+                "gitlab.example.com",
+                date(2024, 1, 1),
+                date(2024, 1, 31),
+            )
+
+    @patch("iptax.did.did.cli.main")
+    def test_warning_log_during_did_call_does_not_raise(
+        self, mock_did_main: Mock
+    ) -> None:
+        """Simulate did.cli.main() logging a WARNING -- assert no exception raised."""
+
+        def mock_did_main_with_warning(*_args: object) -> tuple[list[object]]:
+            logging.getLogger("did").warning("Some non-fatal warning from did")
+            mock_user = Mock()
+            mock_user.stats = []
+            return ([mock_user],)
+
+        mock_did_main.side_effect = mock_did_main_with_warning
+
+        # Should not raise -- warnings are acceptable
+        changes = _fetch_provider_changes(
+            "github.com",
+            date(2024, 1, 1),
+            date(2024, 1, 31),
+        )
+        assert changes == []
+
+    @patch("iptax.did.did.cli.main")
+    def test_error_message_is_clean_no_future_repr(self, mock_did_main: Mock) -> None:
+        """Error message must strip Future repr but keep useful text."""
+
+        def mock_did_main_with_future_error(*_args: object) -> tuple[list[object]]:
+            logging.getLogger("did").error(
+                "Skipping <Future at 0x7f599b6cbc90 state=finished raised ReportError>"
+                " due to Unable to connect to 'https://gitlab.example.com'"
+            )
+            mock_user = Mock()
+            mock_user.stats = []
+            return ([mock_user],)
+
+        mock_did_main.side_effect = mock_did_main_with_future_error
+
+        with pytest.raises(DidIntegrationError) as exc_info:
+            _fetch_provider_changes(
+                "gitlab.example.com",
+                date(2024, 1, 1),
+                date(2024, 1, 31),
+            )
+
+        error_msg = str(exc_info.value)
+        assert "<Future at 0x7f599b6cbc90" not in error_msg
+        assert "Unable to connect to" in error_msg
+
+    @patch("iptax.did.did.cli.main")
+    def test_logging_handler_is_temporary(self, mock_did_main: Mock) -> None:
+        """The did logger must have no extra handlers before and after the call."""
+        did_logger = logging.getLogger("did")
+        handlers_before = list(did_logger.handlers)
+
+        mock_user = Mock()
+        mock_user.stats = []
+        mock_did_main.return_value = ([mock_user],)
+
+        _fetch_provider_changes(
+            "github.com",
+            date(2024, 1, 1),
+            date(2024, 1, 31),
+        )
+
+        handlers_after = list(did_logger.handlers)
+        assert handlers_after == handlers_before
+
+
 class TestFetchChanges:
     """Test fetch_changes function."""
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1386,8 +1386,28 @@ class TestReportData:
         assert en == "November 2024"
         assert pl == "Listopad 2024"
 
-    def test_hours_must_be_positive(self):
-        """Test that hours must be greater than 0."""
+    def test_hours_must_be_non_negative(self):
+        """Test that hours must be >= 0 (zero is valid for PTO months)."""
+        report = ReportData(
+            month="2024-11",
+            start_date=date(2024, 11, 1),
+            end_date=date(2024, 11, 30),
+            changes_since=date(2024, 10, 26),
+            changes_until=date(2024, 11, 23),
+            total_hours=0,
+            creative_hours=0,
+            creative_percentage=80,
+            workday_entries=[],
+            employee_name="John Doe",
+            supervisor_name="Jane Smith",
+            product_name="Test Product",
+        )
+
+        assert report.total_hours == 0
+        assert report.creative_hours == 0
+
+    def test_hours_must_not_be_negative(self):
+        """Test that negative hours are rejected."""
         with pytest.raises(ValidationError) as exc_info:
             ReportData(
                 month="2024-11",
@@ -1395,7 +1415,7 @@ class TestReportData:
                 end_date=date(2024, 11, 30),
                 changes_since=date(2024, 10, 26),
                 changes_until=date(2024, 11, 23),
-                total_hours=0,
+                total_hours=-1,
                 creative_hours=0,
                 creative_percentage=80,
                 workday_entries=[],
@@ -1404,4 +1424,4 @@ class TestReportData:
                 product_name="Test Product",
             )
 
-        assert "greater than 0" in str(exc_info.value).lower()
+        assert "greater than or equal to 0" in str(exc_info.value).lower()


### PR DESCRIPTION
## Summary

Fixes #57 (Can't create a report without data) and fixes #54 (collect silently continues with partial data when Did provider fails).

### Problem

**#57**: Users on long PTO with zero code changes couldn't generate reports. The tool exited with `No changes to review` (exit code 1), even though PTO/holiday hours were valid.

**#54**: When a Did provider (e.g., GitLab) was unreachable, the tool silently saved a report with partial data. The `did` library logs errors via Python's `logging` module, which bypassed the `redirect_stderr()` capture.

### Fix

**#54 -- Detect Did provider errors:**
- Added `_DidErrorCapture` context manager that attaches a temporary logging handler to the `did` logger during `did.cli.main()`, captures ERROR-level records, and raises `DidIntegrationError`
- Raw `<Future at 0x...>` dumps are stripped from error messages
- Added `did` to third-party logger redirect list

**#57 -- Allow zero-change reports:**
- Extracted `_load_report()` from `_load_report_for_review()` so `dist_flow` doesn't require changes
- Removed hard blocks in `_validate_dist_readiness()` and `compile_report()` for empty changes
- Changed `ReportData.total_hours` and `creative_hours` from `gt=0` to `ge=0`
- Added user confirmation prompt when zero changes are found (`Continue with a zero-change report?`)
- Review flow still rejects zero-change reports (correct, nothing to review)

### Changes

| File | What |
|------|------|
| `src/iptax/did.py` | Logging interceptor for Did errors |
| `src/iptax/utils/logging.py` | Added `did` to logger redirect |
| `src/iptax/cli/flows.py` | Extracted `_load_report()`, added zero-change prompt, extracted `_handle_existing_inflight()` |
| `src/iptax/report/compiler.py` | Removed two "no changes" guards |
| `src/iptax/models.py` | `ge=0` for hours fields |
| `tests/` | 13 new tests, 8 updated tests |

### Testing

`make verify` passes: formatting, linting, typing, 900 unit tests, 11 e2e tests.

Assisted-by: 🤖 Claude Opus 4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow generating zero‑change reports (PTO months) and fail fast on `did` provider errors to avoid saving partial data. Fixes #57 and #54.

- **Bug Fixes**
  - Detect `did` provider failures and abort collection: capture ERROR logs during `did.cli.main`, strip noisy Future repr from messages, redirect the `did` logger, and attach the handler only to `did` to avoid duplicates.
  - Allow zero‑change reports: accept 0 hours, remove “no changes” guards in compilation, prompt to confirm when no changes are found, let `dist` proceed without changes while `review` still requires them, and mark Did as complete via `did_collected` (auto‑inferred from `changes` for legacy caches).

<sup>Written for commit 509403f36dc32c3c332195a86076deedf1ca6002. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cardil/iptax/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

